### PR TITLE
add defaults for runner, collections, and ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN dnf install -y \
 
 ## Install Python Dependencies
 COPY deps/python.txt deps-python.txt
-RUN pip install --upgrade pip \
+RUN pip install --upgrade pip wheel \
     && pip install --no-cache-dir -r deps-python.txt
 
 ## Setup Python Workarounds

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM quay.io/ansible/ansible-runner:stable-2.10-devel
+ARG BASE_IMAGE_URI=quay.io/ansible/ansible-runner
+ARG BASE_IMAGE_TAG=stable-2.10-devel
+
+FROM ${BASE_IMAGE_URI}:${BASE_IMAGE_TAG}
 
 ARG BUILD_DATE
 ARG IMAGE_FULL_NAME
@@ -21,6 +24,7 @@ COPY deps/azure-cli.repo /etc/yum.repos.d/azure-cli.repo
 COPY deps/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 
 # Need to match the python devel ver to base image ver, currently 3.8
+# Update readme if you change Python version!
 RUN dnf install -y \
     python38-devel \
     git \
@@ -46,6 +50,11 @@ RUN pip install git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy
 ## Install Ansible Dependencies
 COPY deps/ansible.yml deps-ansible.yml
 RUN ansible-galaxy install -r deps-ansible.yml
+
+# Copy in config files
+COPY env /runner/env
+COPY inventory /runner/inventory
+COPY ansible.cfg ansible.cfg
 
 ## Ensure gcloud and az are on global path
 ENV PATH "$PATH:/home/runner/.local/bin"

--- a/README.adoc
+++ b/README.adoc
@@ -26,6 +26,7 @@ This file sets the default names and variables used such as the image tag and co
 ### build.sh
 Arguments: None +
 This is a convenience script to build the image locally and tag it as `cldr-ansible-runner:latest` by default. +
+It will stop and remove any currently running instances of the named container.  +
 The image is approx ~2GB when fully constructed, which is why we have opted not to host it prebuilt at this time.
 
 ### run_project.sh
@@ -38,42 +39,25 @@ This is a convenience script to complete the following actions:
 * At this point it branches; either it will execute arbitrary commands and exit if they are passed in additionally to the project_dir, or it will enter a shell by default if no other arguments are passed
 
 *Examples:*  +
-`./run_project.sh /path/to/myProject`  +
-This would launch the container with myProject mounted in /runner/project within the container, and drop the user in a container shell with all tools available along with their various host machine user profile directories mounted. +
+`./run_project.sh /path/to/PycharmProjects`  +
+This would launch the container with PycharmProjects mounted in /runner/project within the container, and drop the user in a container shell with all tools available along with their various host machine user profile directories mounted. +
 This is an excellent environment in which to manage your various cloud credentials without resolving dependencies on your host machine, or interactively install further dependencies, or execute playbooks, etc.
 
 `./run_project.sh /path/to/myProject ansible-runner run -p site.yml /runner -vv`  +
 This would launch ansible-runner with the full path to myProject in /runner/project within the container. It would automatically execute ansible-runner with the playbook site.yml with /runner as the working directory and verbosity at 2v's, and then return to the host shell when complete. +
 This is an excellent shortcut to scripted execution where the user has already set up various profiles.
 
+### Other Considerations
+ansible.cfg is configured to set long timeouts, currently based on the longest running CDP Public Canary job at 150mins
+ansible.cfg also adds the path /runner/project/collections as a root for Ansible Collections, so if you happen to have your collections under development in this path (strongly recommended) they will be automatically discovered by the container alongside collections in the default paths.
+
+### Limitations
+We do not currently bring logs and build artifacts back to the host machine before stopping or removing the container, you should retrieve any artifacts you want to keep at the end of your session.
+
+
 ## Included Components
 
-### Cloud Service CLIs
-
-* Azure CLI
-* AWS CLI
-* GCloud CLI
-* CDP CLI
-
-### Ansible Collections
-
-* AWS Amazon/Community
-* Google Cloud
-* Azure Cloud
-* Azure Netapp
-
-### Ansible Roles
-
-* postgresql Role by geerlingguy
-* mysql Role by geerlingguy
-
-### Python Modules
-
-* Aws
-* Openstack
-* Azure
-* Google Auth (not full module set)
-* cdpy / CDPCLI
+Please see included files under ./deps
 
 ## Developers
 Note that sequencing and dependency changes should be annotated in comments as to _why_ that change is considered necessary.  +

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,7 @@ callback_whitelist = ansible.posix.profile_tasks
 collections_path = /home/runner/.ansible/collections:/runner/project/ansible_dev/collections
 roles_path = /home/runner/.ansible/roles:/runner/project/ansible_dev/roles
 host_key_checking = False
+gathering = smart
 
 [ssh_connection]
 retries = 10

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+callback_whitelist=profile_tasks
+enable_task_debugger=True
+collections_paths=/runner/project
+
+[ssh_connection]
+retries=10

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,9 @@
 [defaults]
-callback_whitelist=profile_tasks
-enable_task_debugger=True
-collections_paths=/runner/project
+inventory=inventory
+callback_whitelist = ansible.posix.profile_tasks
+collections_path = /home/runner/.ansible/collections:/runner/project/ansible_dev/collections
+roles_path = /home/runner/.ansible/roles:/runner/project/ansible_dev/roles
+host_key_checking = False
 
 [ssh_connection]
-retries=10
+retries = 10

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ fi
 
 
 ensure_docker_is_running
+ensure_container_removal
 build_docker_image
 
 exit 0

--- a/common.sh
+++ b/common.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Update readme if you change versions!
+BASE_IMAGE_URI="quay.io/ansible/ansible-runner"
+BASE_IMAGE_TAG="stable-2.10-devel"
 IMAGE_NAME=cldr-ansible-runner
 IMAGE_TAG=latest
 IMAGE_FULL_NAME=${IMAGE_NAME}:${IMAGE_TAG}
@@ -11,10 +14,19 @@ ensure_docker_is_running() {
   { docker info >/dev/null 2>&1; echo "Docker OK"; } || { echo "Docker is required and does not seem to be running - please start Docker and retry" ; exit 1; }
 }
 
+ensure_container_removal() {
+  echo "Ensuring container ${CONTAINER_NAME} is not running on system"
+  docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q . && docker stop "${CONTAINER_NAME}" && docker rm -fv "${CONTAINER_NAME}"
+}
+
 build_docker_image() {
+  echo "Checking for updates to ansible-runner base image"
+  docker pull ${BASE_IMAGE_URI}:${BASE_IMAGE_TAG}
   echo "Building image and tagging as ${IMAGE_FULL_NAME}"
   docker build \
     -t "${IMAGE_FULL_NAME}" \
+    --build-arg BASE_IMAGE_URI=${BASE_IMAGE_URI} \
+    --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
     --build-arg IMAGE_FULL_NAME="${IMAGE_FULL_NAME}" \
     --build-arg BUILD_DATE="${BUILD_DATE}" \
     .

--- a/deps/ansible.yml
+++ b/deps/ansible.yml
@@ -13,7 +13,9 @@ collections:
   - community.aws
   - google.cloud
   - azure.azcollection
-  - netapp.azure
+  - name: https://github.com/ansible-collections/netapp.git#ansible_collections/netapp/azure
+    type: git
+#  - netapp.azure
 
 # Append other roles to this list.
 roles:

--- a/deps/ansible.yml
+++ b/deps/ansible.yml
@@ -4,6 +4,11 @@
 #    type: git
 #    version: mybranch
 collections:
+  - community.general
+  - community.postgresql
+  - community.crypto
+  - community.mysql
+  - ansible.posix
   - amazon.aws
   - community.aws
   - google.cloud

--- a/deps/python.txt
+++ b/deps/python.txt
@@ -9,6 +9,7 @@ netaddr
 
 # Json manipulation
 jsonmerge
+deepdiff>=5
 
 # AWS
 awscli>=1.18.222
@@ -23,7 +24,7 @@ openstacksdk
 -r https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt
 
 # NetApp Collection requirements
-azure-mgmt-netapp
+azure-mgmt-netapp>=1.0.0
 
 # Google Collection requirements
 google-auth

--- a/deps/python.txt
+++ b/deps/python.txt
@@ -1,3 +1,6 @@
+# Python internals
+wheel
+
 # CVE avoidance
 requests[security]>2.5.3
 urllib3>1.24.2

--- a/env/envvars
+++ b/env/envvars
@@ -1,0 +1,2 @@
+---
+ANSIBLE_CONFIG=/runner/ansible.cfg

--- a/env/settings
+++ b/env/settings
@@ -1,0 +1,4 @@
+---
+idle_timeout: 1800
+job_timeout: 10800
+pexpect_timeout: 10

--- a/inventory/default
+++ b/inventory/default
@@ -1,1 +1,0 @@
-localhost

--- a/inventory/default
+++ b/inventory/default
@@ -1,0 +1,1 @@
+localhost

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -1,0 +1,1 @@
+localhost


### PR DESCRIPTION
Add community.general to dependencies to explicitly install it so ipify is available
Add default ansible-runner configurations in /env
Add default ansible.cfg file and link to ansible-runner
Add /runner/project/collections to default collections paths for developer convenience
Add function to convenience scripts to ensure running container is stopped and replaced during rebuild
Update readme to reflect changes