### PR TITLE
reconcile local test and github action Workflow for Docker build and push

### DIFF
--- a/.github/workflows/publish_image_github_packages.yml
+++ b/.github/workflows/publish_image_github_packages.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Push to GitHub Packages for Base Build
         uses: docker/build-push-action@v2.3.0
         with:
-          add_git_labels: true
           tags: ghcr.io/cloudera-labs/cldr-ansible-runner:base-${{ env.RELEASE_VERSION }}
+          push: true
           build-args: |
             BUILD_DATE=${{ steps.date.outputs.time }}
             CDPY=true
@@ -40,6 +40,7 @@ jobs:
       - name: Push to GitHub Packages for Full Build
         uses: docker/build-push-action@v2.3.0
         with:
+          push: true
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-ansible-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
@@ -58,6 +59,7 @@ jobs:
       - name: Push to GitHub Packages for AWS only
         uses: docker/build-push-action@v2.3.0
         with:
+          push: true
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-ansible-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
@@ -73,6 +75,7 @@ jobs:
       - name: Push to GitHub Packages for GCP only
         uses: docker/build-push-action@v2.3.0
         with:
+          push: true
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-ansible-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
@@ -88,6 +91,7 @@ jobs:
       - name: Push to GitHub Packages for Azure only
         uses: docker/build-push-action@v2.3.0
         with:
+          push: true
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-ansible-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # Cloudera Labs Ansible-Runner
 
-Readme last updated: 2021-01-30
+Readme last updated: 2021-03-17
 
 A Container image for running Ansible Playbooks and other common tools used with Cloudera Software on various Infrastructure Platforms. +
 


### PR DESCRIPTION
Remove git-labels from workflow, as current github actions have deprecated it
Set explicit push for workflow builds, as local github actions testing with nektos act require it even if actual github actions do not
Increment date in readme to reflect end of this development cycle.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>