### PR TITLE
Enable pipelining by default in ansible.cfg

### DIFF
--- a/payload/ansible.cfg
+++ b/payload/ansible.cfg
@@ -5,6 +5,7 @@ collections_path = /home/runner/.ansible/collections:/runner/project/ansible_dev
 roles_path = /home/runner/.ansible/roles:/runner/project/ansible_dev/roles
 host_key_checking = False
 gathering = smart
+pipelining = True
 
 [ssh_connection]
 retries = 10


### PR DESCRIPTION
Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>